### PR TITLE
Add a few basic tests for the compiled executable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,15 +47,6 @@ jobs:
     - name: "return to workspace directory"
       run: cd $GITHUB_WORKSPACE
       shell: bash
-    - name: "download jeep"
-      run: git clone --depth=1 https://github.com/pyrmont/jeep.git .jeep
-      shell: bash
-    - name: "install jeep"
-      run: cd .jeep && janet --install .
-      shell: bash
-    - name: "return to workspace directory"
-      run: cd $GITHUB_WORKSPACE
-      shell: bash
     - name: "run tests"
-      run: jeep test -R
+      run: 'for f in test/*.janet; do janet "$f" || { rc=$?; break; }; done; (exit ${rc:-0})'
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,15 @@ jobs:
     - name: "return to workspace directory"
       run: cd $GITHUB_WORKSPACE
       shell: bash
+    - name: "download jeep"
+      run: git clone --depth=1 https://github.com/pyrmont/jeep.git .jeep
+      shell: bash
+    - name: "install jeep"
+      run: cd .jeep && janet --install .
+      shell: bash
+    - name: "return to workspace directory"
+      run: cd $GITHUB_WORKSPACE
+      shell: bash
     - name: "run tests"
-      run: 'for f in test/*.janet; do janet "$f" || { rc=$?; break; }; done; (exit ${rc:-0})'
+      run: jeep test -R
       shell: bash

--- a/deps/argy-bargy/argy-bargy.janet
+++ b/deps/argy-bargy/argy-bargy.janet
@@ -1,4 +1,4 @@
-# Global values
+## Global values
 
 (var max-width "Maximum number of columns to use for usage messages" 120)
 (var pad-inset "Number of columns to pad argument descriptions from the left" 4)
@@ -11,8 +11,41 @@
 (def- err @"")
 (def- help @"")
 
+## Column calculation
 
-# Utility functions
+(defn- devnull
+  ```
+  Gets the /dev/null equivalent for the current platform as a file
+  ```
+  []
+  (os/open (if (= :windows (os/which)) "NUL" "/dev/null") :rw))
+
+(defn- get-cols
+  ```
+  Gets the columns of the current terminal
+  ```
+  [&opt force?]
+  (if (and cols (not force?))
+    (break cols))
+  (def win? (= :windows (os/which)))
+  (def cmd
+    (if win?
+      ["powershell" "-command" "&{(get-host).ui.rawui.WindowSize.Width;}"]
+      ["stty" "size"]))
+  (with [null (devnull)]
+    (with [f (file/temp)]
+      (def exit-code (os/execute cmd :p {:out f :err null}))
+      (if (zero? exit-code)
+        (do
+          (file/seek f :set 0)
+          (def out (string/trim (file/read f :all)))
+          (def tcols (if win?
+                       (scan-number out)
+                       (scan-number (-> (string/split " " out) (get 1)))))
+          (min tcols max-width))
+        max-width))))
+
+## Argument parsing
 
 (defn- conform-args
   ```
@@ -37,132 +70,105 @@
     (++ i))
   res)
 
+(defn- make-parser
+  ```
+  Makes the parser used to parse arguments
 
-(defn- conform-rules
+  The 'parser' is really a set of structures that are used to look up
+  options, parameters and subcommands.
   ```
-  Conforms rules
-  ```
-  [rules]
+  [config]
+  (def ordered @{:opts @[] :params @[] :subs @[]})
+  (def config-rules (get config :rules []))
+  (def config-subs (get config :subs []))
+  # lookup tables for arguments
+  (def long-opts @{})
+  (def short-opts @{})
+  (def params @[])
+  # categorise argument rules
   (var rest-capture? false)
-  (def orules @[])
-  (def prules @[])
   (var help? false)
-
   (var i 0)
-  (while (< i (length rules))
-    (def k (get rules i))
-    (if (string/has-prefix? hr k)
-      (array/push orules [hr nil])
+  (while (< i (length config-rules))
+    (def k (get config-rules i))
+    (cond
+      # option divider
+      (string/has-prefix? hr k)
+      (array/push (ordered :opts) [hr nil])
+      # parameter divider
+      (and (keyword? k) (string/has-prefix? hr (string k)))
+      (array/push (ordered :params) [hr nil])
+      # default
       (do
-        (unless (or (string? k) (keyword? k))
-          (errorf "names of rules must be strings or keywords: %p" k))
-        (def v (get rules (++ i)))
-        (when (nil? v)
-          (errorf "number of elements in rules must be even: %p" rules))
-        (unless (or (struct? v) (table? v))
-          (errorf "each rule must be struct or table: %p" v))
-        (unless (or (keyword? k) ({:flag true :count true :single true :multi true} (v :kind)))
-          (errorf "each option rule must be of kind :flag, :count, :single or :multi: %p" v))
-        (when (and (keyword? k) rest-capture? (v :splat?))
-          (errorf "multiple parameter rules cannot capture :splat? %p" v))
+        (assertf (or (string? k) (keyword? k))
+                 "names of rules must be strings or keywords: %p" k)
+        (def v (get config-rules (++ i)))
+        (assertf (not (nil? v))
+                 "number of elements in rules must be even: %p" config-rules)
+        (assertf (dictionary? v)
+                 "each rule must be struct or table: %p" v)
+        (assertf (or (keyword? k) (index-of (v :kind) [:flag :count :single :multi :help]))
+                 "each option rule must be of kind :flag, :count, :single, :multi or :help: %p" v)
+        (assertf (not (and rest-capture? (keyword? k) (v :splat?)))
+                 "multiple parameter rules cannot capture :splat?: %p" v)
         (cond
+          # options
           (string? k)
-          (let [name (if (string/has-prefix? "--" k) (string/slice k 2) k)]
-            (when (nil? (peg/find '(* :w (some (+ :w (set "-_"))) -1) name))
-              (errorf "option name must be at least two alphanumeric characters: %p" name))
-            (array/push orules [name (merge v {:name name})])
+          (do
+            (def name (if (string/has-prefix? "--" k) (string/slice k 2) k))
+            (assertf (peg/find '(* :w (some (+ :w (set "-_"))) -1) name)
+                     "option name must be two or more alphanumeric characters: %p" name)
+            # name can be used in descriptions
+            (def rule (merge v {:name name}))
+            (put long-opts name rule)
+            (when (v :short)
+              (put short-opts (v :short) rule))
+            (array/push (ordered :opts) [name rule])
             (set help? (= "help" name)))
-
+          # parameters
           (keyword? k)
           (do
-            (array/push prules [k v])
+            (array/push params [k v])
+            (array/push (ordered :params) [k v])
             (set rest-capture? (v :splat?))))))
     (++ i))
-
+  # add help rule
   (unless help?
-    (array/push orules ["help" {:name   "help"
-                                :kind   :help
-                                :noex?  true
-                                :short  "h"
-                                :help   "Show this help message."}]))
-  [orules prules])
-
-
-(defn- conform-subconfigs
-  ```
-  Conforms subconfigs
-  ```
-  [subcommands]
-  (def subconfigs @[])
-  (var i 0)
-  (while (< i (length subcommands))
-    (def k (get subcommands i))
+    (def help-rule {:name   "help"
+                    :kind   :help
+                    :noex?  true
+                    :short  "h"
+                    :help   "Show this help message."})
+    (put long-opts "help" help-rule)
+    (put short-opts "h" help-rule)
+    (array/push (ordered :opts) ["help" help-rule]))
+  # lookup table for subcommands
+  (def subs @{})
+  # categorise subs
+  (set i 0)
+  (while (< i (length config-subs))
+    (def k (get config-subs i))
     (if (string/has-prefix? hr k)
-      (array/push subconfigs [hr nil])
+      (array/push (ordered :subs) [hr nil])
       (do
-        (unless (string? k)
-          (errorf "names of subcommands must be strings: %p" k))
-        (def v (get subcommands (++ i)))
-        (when (nil? v)
-          (errorf "number of elements in subcommands must be even: %p" subcommands))
-        (unless (or (struct? v) (table? v))
-          (errorf "each subcommand must be struct or table: %p" v))
-        (array/push subconfigs [k v])))
+        (assertf (string? k)
+                 "name of subcommands must be strings: %p" k)
+        (def v (get config-subs (++ i)))
+        (assertf (not (nil? v))
+                 "number of elements in subcommands must be even: %p" config-subs)
+        (assertf (dictionary? v)
+                 "each subcommand must be struct or table: %p" v)
+        (put subs k v)
+        (array/push (ordered :subs) [k v])))
     (++ i))
-  subconfigs)
+  # return value
+  @{:long-opts long-opts
+    :short-opts short-opts
+    :params params
+    :subs subs
+    :ordered ordered})
 
-
-(defn- get-cols
-  ```
-  Gets the columns in the terminal
-  ```
-  []
-  (if cols
-    cols
-    (do
-      (def win? (= :windows (os/which)))
-      (def cmd
-        (if win?
-          ["powershell" "-command" "&{(get-host).ui.rawui.WindowSize.Width;}"]
-          ["stty" "size"]))
-      (with [f (file/temp)]
-        (def exit-code (os/execute cmd :p {:out f :err nil}))
-        (if (zero? exit-code)
-          (do
-            (file/seek f :set 0)
-            (def out (string/trim (file/read f :all)))
-            (def tcols (if win?
-                         (scan-number out)
-                         (scan-number (-> (string/split " " out) (get 1)))))
-            (min tcols max-width))
-          max-width)))))
-
-
-(defn- get-rule
-  ```
-  Gets a rule matching a name
-  ```
-  [name rules]
-  (var res nil)
-  (each [k v] rules
-    (when (or (= k name) (= (get v :short) name))
-      (set res v)
-      (break)))
-  res)
-
-
-(defn- get-subconfig
-  ```
-  Gets a subconfig matching a name
-  ```
-  [subconfigs name]
-  (var res nil)
-  (each [k v] subconfigs
-    (when (= k name)
-      (set res v)
-      (break)))
-  res)
-
+## String manipulation
 
 (defn- split-words
   ```
@@ -181,17 +187,17 @@
         (array/push res (string buf))
         (buffer/clear buf)
         (cond
+          # newline
           (= 10 next-c)
           (array/push res (string/from-bytes curr-c next-c))
-
+          # space
           (= 32 next-c)
           nil
-
+          # default
           (buffer/push buf next-c)))))
   (unless (empty? buf)
     (array/push res (string buf)))
   res)
-
 
 (defn- stitch
   ```
@@ -202,7 +208,6 @@
   [parts &opt sep]
   (default sep " ")
   (string/join (filter truthy? parts) sep))
-
 
 (defn- indent-str
   ```
@@ -220,30 +225,30 @@
   (var first? true)
   (each word (split-words str)
     (cond
+      # first word
       first?
       (do
         (buffer/push res word)
         (+= currw (length word))
         (set first? false))
-
+      # blank line
       (= "\n\n" word)
       (do
         (buffer/push res word (string/repeat " " hangp))
         (set currw hangp)
         (set first? true))
-
+      # word fits on line
       (< (+ currw 1 (length word)) maxw)
       (do
         (buffer/push res " " word)
         (+= currw (+ 1 (length word))))
-
+      # default
       (do
         (buffer/push res "\n" (string/repeat " " hangp) word)
         (set currw (+ hangp (length word))))))
   res)
 
-
-# Usage messages
+## Usage messages
 
 (defn- usage-error
   ```
@@ -254,7 +259,6 @@
     (xprint err command ": " ;msg)
     (xprint err "Try '" command " --help' for more information.")))
 
-
 (defn- usage-parameters
   ```
   Prints the usage descriptions for the parameters to `help`
@@ -262,7 +266,7 @@
   [info rules]
   (def usages @[])
   (var pad 0)
-
+  # prepare usage descriptions
   (each [name rule] rules
     (def proxy (or (rule :proxy) name))
     (def usage-prefix (string " " proxy))
@@ -272,7 +276,7 @@
                  (string "(Default: " (rule :default) ")"))]))
     (array/push usages [usage-prefix usage-help])
     (set pad (max (+ pad-inset (length usage-prefix)) pad)))
-
+  # print usage descriptions
   (unless (empty? usages)
     (xprint help)
     (if (info :params-header)
@@ -283,7 +287,6 @@
       (def startp (- pad (length prefix)))
       (xprint help prefix (indent-str msg (length prefix) startp pad (- cols pad-right))))))
 
-
 (defn- usage-options
   ```
   Prints the usage descriptions for the options to `help`
@@ -291,7 +294,7 @@
   [info rules]
   (def usages @[])
   (var pad 0)
-
+  # prepare usage descriptions
   (each [name rule] rules
     (if (= hr name)
       (array/push usages [nil nil])
@@ -310,7 +313,7 @@
                      (string "(Default: " (rule :default) ")"))]))
         (array/push usages [usage-prefix usage-help])
         (set pad (max (+ pad-inset (length usage-prefix)) pad)))))
-
+  # print usage descriptions
   (unless (empty? usages)
     (xprint help)
     (if (info :opts-header)
@@ -324,16 +327,15 @@
           (def startp (- pad (length prefix)))
           (xprint help prefix (indent-str msg (length prefix) startp pad (- cols pad-right))))))))
 
-
 (defn- usage-subcommands
   ```
   Prints the usage descriptions for the subcommands to `help`
   ```
-  [info subconfigs]
+  [info rules]
   (def usages @[])
   (var pad 0)
-
-  (each [name config] subconfigs
+  # prepare usage descriptions
+  (each [name config] rules
     (if (= hr name)
       (array/push usages [nil nil])
       (do
@@ -341,7 +343,7 @@
         (def usage-help (get config :help ""))
         (array/push usages [usage-prefix usage-help])
         (set pad (max (+ pad-inset (length usage-prefix)) pad)))))
-
+  # print usage descriptions
   (unless (empty? usages)
     (xprint help)
     (if (info :subs-header)
@@ -357,12 +359,11 @@
     (xprint help)
     (xprint help "For more information on each subcommand, type '" command " help <subcommand>'.")))
 
-
 (defn- usage-example
   ```
   Prints a usage example to `help`
   ```
-  [orules prules subconfigs]
+  [parser]
   (xprint help
     (indent-str
       (string "Usage: "
@@ -374,7 +375,7 @@
                                           (= :multi (rule :kind)))
                                   (string " <" (or (rule :proxy) (rule :name)) ">"))
                                 "]")))
-                    orules)
+                    (get-in parser [:ordered :opts]))
               ;(map (fn [[name rule]]
                       (unless (rule :hide?)
                         (def proxy (or (rule :proxy) name))
@@ -385,51 +386,43 @@
                                 (when (rule :splat?) "...")
                                 ">"
                                 (unless (rule :req?) "]"))))
-                    prules)
-              (unless (empty? subconfigs)
+                    (get-in parser [:ordered :params]))
+              (unless (empty? (parser :subs))
                 " <subcommand> [<args>]"))
       0
       0
       (+ 7 (length command) 1)
       (- cols pad-right))))
 
-
 (defn- usage
   ```
   Prints the usage message to `help`
   ```
-  [config]
+  [config parser]
   (def info (get config :info {}))
-  (def [orules prules] (conform-rules (get config :rules [])))
-  (def subconfigs (conform-subconfigs (get config :subs [])))
-
+  (def rules (parser :ordered))
   (when (and (empty? err) (empty? help))
+    (set cols (get-cols))
     (if (info :usages)
       (each example (info :usages)
         (xprint help example))
-      (usage-example orules prules subconfigs))
-
+      (usage-example parser))
     (when (info :about)
       (xprint help)
       (xprint help (indent-str (info :about) 0)))
-
-    (unless (empty? prules)
-      (def shown-rules (filter (fn [[n r]] (not (has-key? r :hide?))) prules))
+    (unless (empty? (rules :params))
+      (def shown-rules (filter (fn [[n r]] (not (has-key? r :hide?))) (rules :params)))
       (usage-parameters info shown-rules))
-
-    (unless (empty? orules)
-      (def shown-rules (filter (fn [[n r]] (not (has-key? r :hide?))) orules))
+    (unless (empty? (rules :opts))
+      (def shown-rules (filter (fn [[n r]] (not (has-key? r :hide?))) (rules :opts)))
       (usage-options info shown-rules))
-
-    (unless (empty? subconfigs)
-      (usage-subcommands info subconfigs))
-
+    (unless (empty? (rules :subs))
+      (usage-subcommands info (rules :subs)))
     (when (info :rider)
       (xprint help)
       (xprint help (indent-str (info :rider) 0)))))
 
-
-# Processing functions
+## Conversion
 
 (defn- convert
   ```
@@ -444,65 +437,71 @@
   (if (nil? converter)
     arg
     (cond
+      # predefined converter
       (keyword? converter)
       (case converter
+        # string conversion
         :string
         arg
-
+        # integer conversion
         :integer
         (let [[ok? res] (protect (scan-number arg))]
           (when (and ok? (int? res))
             res)))
-
+      # user-defined converter
       (function? converter)
       (converter arg))))
 
+## Consumption
 
 (defn- consume-option
   ```
   Consumes an option
   ```
-  [result orules args i &opt short?]
+  [result rules args i &opt short?]
   (def opts (result :opts))
-  (def shorts (result :shorts))
   (def arg (in args i))
   (def name (string/slice arg (if short? 1 2)))
-  (if-let [rule (get-rule name orules)
-           long-name (rule :name)
-           kind (rule :kind)]
-    (case kind
-      :flag
-      (do
-        (put opts long-name true)
-        (inc i))
-
-      :count
-      (do
-        (put opts long-name (-> (opts long-name) (or 0) inc))
-        (inc i))
-
-      (if (or (= kind :single)
-              (= kind :multi))
-        (if-let [input (get args (inc i))]
-          (if-let [val (convert input (rule :value))]
-            (do
-              (case kind
-                :single (put opts long-name val)
-                :multi  (put opts long-name (array/push (or (opts long-name) @[]) val)))
-              (+ 2 i))
-            (usage-error "'" input "' is invalid value for " arg))
-          (usage-error "no value after option of type " kind))))
+  (def rule (rules name))
+  (if rule
+    (do
+      (def long-name (rule :name))
+      (def kind (rule :kind))
+      (case kind
+        # flag options
+        :flag
+        (do
+          (put opts long-name true)
+          (inc i))
+        # count options
+        :count
+        (do
+          (put opts long-name (-> (opts long-name) (or 0) inc))
+          (inc i))
+        # single/multi options
+        (if (or (= kind :single)
+                (= kind :multi))
+          (if-let [input (get args (inc i))]
+            (if-let [val (convert input (rule :value))]
+              (do
+                (case kind
+                  :single
+                  (put opts long-name val)
+                  :multi
+                  (put opts long-name (array/push (or (opts long-name) @[]) val)))
+                (+ 2 i))
+              (usage-error "'" input "' is invalid value for " arg))
+            (usage-error "no value after option of type " kind)))))
     (usage-error "unrecognized option '" arg "'")))
-
 
 (defn- consume-param
   ```
   Consumes a parameter
   ```
-  [result prule args i rem]
+  [result name-rule args i rem]
   (def params (result :params))
   (def arg (args i))
-  (if-let [[name rule] prule]
+  (if-let [[name rule] name-rule]
     (if (rule :splat?)
       (do
         (def vals @[])
@@ -525,30 +524,31 @@
         (usage-error "'" arg "' is invalid value for " (or (rule :proxy) name))))
     (usage-error "too many parameters passed")))
 
+## Checking
 
 (defn- check-options
   ```
   Checks options
   ```
-  [result rules]
+  [result parser]
   (def opts (result :opts))
-  (each [name rule] rules
-    (when (and (not (nil? rule)) (rule :default) (nil? (opts name)))
+  (eachp [name rule] (parser :long-opts)
+    (when (and (rule :default) (nil? (opts name)))
       (put-in result [:opts name] (rule :default)))))
-
 
 (defn- check-params
   ```
   Checks params
   ```
-  [result params rules]
+  [result parser params]
+  (def rules (parser :params))
   (def num-params (length params))
   (var i 0)
   (def num-rules (length rules))
   (var j 0)
   (while (< i num-params)
-    (def rule (get rules j))
-    (set i (consume-param result rule params i (- num-rules j 1)))
+    (def name-rule (rules j))
+    (set i (consume-param result name-rule params i (- num-rules j 1)))
     (++ j))
   (while (< j num-rules)
     (def [name rule] (rules j))
@@ -559,69 +559,69 @@
       (put-in result [:params name] (rule :default)))
     (++ j)))
 
-
 (defn- check-subcommand
   ```
   Checks subcommands
   ```
-  [result config]
-  (unless (or (nil? (config :subs)) (result :sub))
-    (usage config)))
+  [result parser]
+  (unless (or (empty? (parser :subs)) (result :sub))
+    (usage-error "no subcommand provided")))
 
-
-# Parsing functions
+## Parsing
 
 (defn- parse-args-impl
   ```
   Parses arguments recursively if necessary to allow nested subcommands
   ```
   [name config]
+  # set up command
   (set command name)
-
-  (def [orules prules] (conform-rules (get config :rules [])))
-  (def subconfigs (conform-subconfigs (get config :subs [])))
+  # set up parser
+  (def parser (make-parser config))
+  # set up args
   (def args (conform-args (dyn :args)))
-
-  (def result @{:cmd command :opts @{} :params (when (empty? subconfigs) @{})})
+  # set up return value
+  (def result @{:cmd command :opts @{} :params (when (empty? (parser :subs)) @{})})
   (def params @[])
-
+  # loop
   (def num-args (length args))
   (var i 1)
   (while (< i num-args)
     (def arg (get args i))
     (set i (cond
+             # help option
              (or (= "--help" arg) (= "-h" arg))
              (do
                (put-in result [:opts "help"] true)
                (if (= "-h" arg)
                  (put-in result [:opts :h?] true))
-               (usage config))
-
+               (usage config parser))
+             # stop parsing
              (= "--" arg)
              (do
                (array/concat params (array/slice args (inc i)))
                (break))
-
+             # long option
              (string/has-prefix? "--" arg)
-             (consume-option result orules args i)
-
+             (consume-option result (parser :long-opts) args i)
+             # hyphen parameter
              (= "-" arg)
              (do
                (array/push params arg)
                (inc i))
-
+             # short option
              (string/has-prefix? "-" arg)
-             (consume-option result orules args i true)
-
-             (empty? subconfigs)
+             (consume-option result (parser :short-opts) args i true)
+             # no subcommands
+             (empty? (parser :subs))
              (do
                (array/push params arg)
                (inc i))
-
+             # subcommands
              (do
                (def help? (= "help" arg))
                (def subcommand (if help? (get args (inc i)) arg))
-               (def subconfig (get-subconfig subconfigs subcommand))
+               (def subconfig (get-in parser [:subs subcommand]))
                (if subcommand
                  (if subconfig
                    (if (not help?)
@@ -636,17 +636,19 @@
                        (put-in result [:opts "help"] true)
                        (put result :sub @{:cmd subcommand})
                        (set command (string command " " subcommand))
-                       (usage subconfig)))
+                       (def subparser (make-parser subconfig))
+                       (usage subconfig subparser)))
                    (usage-error "unrecognized subcommand '" subcommand "'"))
                  (usage-error "no subcommand specified after 'help'")))))
+    # no further processing
     (when (nil? i)
       (break)))
-
+  # check validity
   (when (and (empty? err) (empty? help))
-    (check-subcommand result config)
-    (check-options result orules)
-    (check-params result params prules))
-
+    (check-subcommand result parser)
+    (check-options result parser)
+    (check-params result parser params))
+  # return value
   result)
 
 (defn parse-args
@@ -755,7 +757,6 @@
   messages that may have been generated during parsing.
   ```
   [name config]
-  (set cols (get-cols))
   (def res (-> (parse-args-impl name config)
                (merge-into {:err (string err) :help (string help)})))
   (buffer/clear err)

--- a/test/executable.janet
+++ b/test/executable.janet
@@ -1,0 +1,58 @@
+(use ../deps/testament)
+
+(defn str-to-stream
+  [str]
+  (def [r w] (os/pipe))
+  (:write w str)
+  (:close w)
+  r)
+
+(defn shell-capture
+  [cmd test_stdin]
+  (let [x (os/spawn cmd : {:in test_stdin :out :pipe :err :pipe})
+        o (:read (x :out) :all)
+        e (:read (x :err) :all)]
+    (:wait x)
+    [(get x :return-code) o e]))
+
+(deftest cli-no-args
+  (is (deep=
+    [1 nil @"predoc: path is required\nTry 'predoc --help' for more information.\n"]
+    (shell-capture ["./predoc"] stdin))))
+
+(deftest cli-bad-option
+  (is (deep=
+    [1 nil @"predoc: unrecognized option '--bad-option'\nTry 'predoc --help' for more information.\n"]
+    (shell-capture ["./predoc" "--bad-option"] stdin))))
+
+(deftest cli-good-input
+  (def [exit_code test_out test_err] 
+    (shell-capture ["./predoc" "--output" "-" "--name" "Testing" "-"]
+                   (str-to-stream "NAME\n====\n\n**predoc** - converter from Predoc to mdoc\n")))
+  (is (= 0 exit_code))
+  (is (deep=
+"
+.\n
+.Sh NAME\n
+.Ic predoc\n
+.Nd converter from Predoc to mdoc\n
+\n"
+    (string/slice test_out -58))) # Strip off beginning time stamp section
+  (is (deep= @"stty: 'standard input': Not a tty\n" test_err)))
+
+(deftest cli-bad-input
+  (def [exit_code test_out test_err] 
+    (shell-capture ["./predoc" "--output" "-" "--name" "Testing" "-"]
+                   (str-to-stream "---\nTitle: Testing(1)\n---")))
+  (is (= 1 exit_code))
+  (is (= nil test_out))
+  (is (deep=
+@"stty: 'standard input': Not a tty\n
+error: could not parse date in frontmatter\n
+  in parse-date [lib/mdoc.janet] on line 133, column 6\n
+  in render-prologue [lib/mdoc.janet] (tail call) on line 430, column 13\n
+  in render-doc [lib/mdoc.janet] (tail call) on line 567, column 5\n
+  in run [lib/cli.janet] (tail call) on line 116, column 21\n"
+    test_err)))
+
+(run-tests!)


### PR DESCRIPTION
Rather than creating a shell script to test the executable I added some test cases using the existing testament test runner in the test folder.  The tests fail if the user does not first compile/build the predoc executable.  I wasn't sure if there was an easy way to add a dependency similar to a Makefile that would compile predoc if it didn't exist when running the test system.